### PR TITLE
Make it easier to concatenate js files.

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -203,4 +203,4 @@
         added: null,                     // Function called each time a new form is added
         removed: null                    // Function called each time a form is deleted
     };
-})(jQuery)
+})(jQuery);


### PR DESCRIPTION
I had a conflict with another JS file that was right after formset.js that didn't start with a semicolon during concatenation.  Adding a semicolon here will make sure that no problems like that ever occur again.
