### PR TITLE
Fixed bug with delete button selector

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -14,7 +14,7 @@
     {
         var options = $.extend({}, $.fn.formset.defaults, opts),
             flatExtraClasses = options.extraClasses.join(' '),
-            totalForms = $('#id_' + options.prefix + '-TOTAL_FORMS'),
+            totalForms = $('#id_' deleteClsSelector+ options.prefix + '-TOTAL_FORMS'),
             maxForms = $('#id_' + options.prefix + '-MAX_NUM_FORMS'),
             childElementSelector = 'input,select,textarea,label,div',
             $$ = $(this),
@@ -57,8 +57,8 @@
                     // last child element of the form's container:
                     row.append('<a class="' + options.deleteCssClass + '" href="javascript:void(0)">' + options.deleteText +'</a>');
                 }
-                var deleteClsSelector = options.deleteCssClass.split(' ').join('.');
-                row.find('a.' + deleteClsSelector).click(function() {
+                var deleteCssSelector = options.deleteCssClass.split(' ').join('.');
+                row.find('a.' + deleteCssSelector).click(function() {
                     var row = $(this).parents('.' + options.formCssClass),
                         del = row.find('input:hidden[id $= "-DELETE"]'),
                         buttonRow = row.siblings("a." + options.addCssClass + ', .' + options.formCssClass + '-add'),


### PR DESCRIPTION
When we have two or more classes like "btn btn-danger" we need to replace spaces with "." to work correctly
