### PR TITLE
fix reindexing on row deletion when multiple formsets are used on a sing...

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -72,9 +72,9 @@
                         row.hide();
                         forms = $('.' + options.formCssClass).not(':hidden');
                     } else {
-                        row.remove();
                         // Update the TOTAL_FORMS count:
-                        forms = $('.' + options.formCssClass).not('.formset-custom-template');
+                        forms = row.parent().find('.' + options.formCssClass + ':not(\'.formset-custom-template\')');
+                        row.remove();
                         totalForms.val(forms.length);
                     }
                     for (var i=0, formCount=forms.length; i<formCount; i++) {


### PR DESCRIPTION
...le page

When multiple formsets are used on a single page and a newly created row is deleted it reindexes over every row on the page, not just the rows in the current formset.

This fixes this behaviour.
