### PR TITLE
Only add delete link when delete checkbox is present

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -114,11 +114,13 @@
                 // Hide any labels associated with the DELETE checkbox:
                 $('label[for="' + del.attr('id') + '"]').hide();
                 del.remove();
+                if (hasChildElements(row) && row.is(':visible')) {
+                    insertDeleteLink(row);
+                }
             }
             if (hasChildElements(row)) {
                 row.addClass(options.formCssClass);
                 if (row.is(':visible')) {
-                    insertDeleteLink(row);
                     applyExtraClasses(row, i);
                 }
             }


### PR DESCRIPTION
Currently the delete link is inserted for every row, but it should only be added if the row has a Django DELETE checkbox.
