### PR TITLE
Django 1.7 MIN_NUM_FORMS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 node_modules/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build/
 node_modules/
-*.pyc
+

--- a/demo/example/forms.py
+++ b/demo/example/forms.py
@@ -61,6 +61,11 @@ ContactFormset = formsets.formset_factory(ContactInfoForm)
 MaxFiveContactsFormset = formsets.formset_factory(ContactInfoForm, extra=5, max_num=5)
 # Define the same formset, with no forms (so we can demo the form template):
 EmptyContactFormset = formsets.formset_factory(ContactInfoForm, extra=0)
+try:
+    # Define the same formset, which will require a minimum of 2 contacts, no extra
+    MinTwoContactsFormset = formsets.formset_factory(ContactInfoForm, extra=0, min_num=2)
+except:
+    pass # django pre 1.7
 
 ###############################################
 ## Plain 'ole Formset with Javascript Widget ##

--- a/demo/example/urls.py
+++ b/demo/example/urls.py
@@ -26,3 +26,10 @@ if major >= 1 and minor >= 2:
         url(r'^max-forms/$', 'formset', {'formset_class': MaxFiveContactsFormset, 'template': 'example/max-forms.html'}, name='example_max_forms'),
         url(r'^empty-form/$', 'formset', {'formset_class': EmptyContactFormset, 'template': 'example/empty-form.html'}, name='example_empty_form'),
     )
+
+if major >=1 and minor >= 7:
+    from example.forms import MinTwoContactsFormset
+    # These examples require Django 1.7 and above:
+    urlpatterns += patterns('example.views',
+        url(r'^min-forms/$', 'formset', {'formset_class': MinTwoContactsFormset, 'template': 'example/min-forms.html'}, name='example_min_forms'),
+    )

--- a/demo/static/js/jquery.formset.js
+++ b/demo/static/js/jquery.formset.js
@@ -16,6 +16,7 @@
             flatExtraClasses = options.extraClasses.join(' '),
             totalForms = $('#id_' + options.prefix + '-TOTAL_FORMS'),
             maxForms = $('#id_' + options.prefix + '-MAX_NUM_FORMS'),
+            minForms = $('#id_' + options.prefix + '-MIN_NUM_FORMS'),
             childElementSelector = 'input,select,textarea,label,div',
             $$ = $(this),
 
@@ -40,10 +41,20 @@
 
             showAddButton = function() {
                 return maxForms.length == 0 ||   // For Django versions pre 1.2
-                    (maxForms.val() == '' || (maxForms.val() - totalForms.val() > 0))
+                    (maxForms.val() == '' || (maxForms.val() - totalForms.val() > 0));
+            },
+
+            /**
+            * Indicates whether delete link(s) can be displayed - when total forms > min forms
+            */
+            showDeleteLinks = function() {
+                return minForms.length == 0 ||   // For Django versions pre 1.7
+                    (minForms.val() == '' || (totalForms.val() - minForms.val() > 0));
             },
 
             insertDeleteLink = function(row) {
+                var delCssSelector = options.deleteCssClass.trim().replace(/\s+/g, '.'),
+                    addCssSelector = options.addCssClass.trim().replace(/\s+/g, '.');
                 if (row.is('TR')) {
                     // If the forms are laid out in table rows, insert
                     // the remove button into the last table cell:
@@ -57,10 +68,15 @@
                     // last child element of the form's container:
                     row.append('<a class="' + options.deleteCssClass + '" href="javascript:void(0)">' + options.deleteText +'</a>');
                 }
-                row.find('a.' + options.deleteCssClass).click(function() {
+                // Check if we're under the minimum number of forms - not to display delete link at rendering
+                if (!showDeleteLinks()){
+                    row.find('a.' + delCssSelector).hide();
+                }
+
+                row.find('a.' + delCssSelector).click(function() {
                     var row = $(this).parents('.' + options.formCssClass),
                         del = row.find('input:hidden[id $= "-DELETE"]'),
-                        buttonRow = row.siblings("a." + options.addCssClass + ', .' + options.formCssClass + '-add'),
+                        buttonRow = row.siblings("a." + addCssSelector + ', .' + options.formCssClass + '-add'),
                         forms;
                     if (del.length) {
                         // We're dealing with an inline formset.
@@ -85,6 +101,10 @@
                                 updateElementIndex($(this), options.prefix, i);
                             });
                         }
+                    }
+                    // Check if we've reached the minimum number of forms - hide all delete link(s)
+                    if (!showDeleteLinks()){
+                        $('a.' + delCssSelector).each(function(){$(this).hide();});
                     }
                     // Check if we need to show the add button:
                     if (buttonRow.is(':hidden') && showAddButton()) buttonRow.show();
@@ -153,7 +173,7 @@
             // FIXME: Perhaps using $.data would be a better idea?
             options.formTemplate = template;
 
-            if ($$.attr('tagName') == 'TR') {
+            if ($$.is('TR')) {
                 // If forms are laid out as table rows, insert the
                 // "add" button in a new table row:
                 var numCols = $$.eq(0).children().length,   // This is a bit of an assumption :|
@@ -171,13 +191,18 @@
             addButton.click(function() {
                 var formCount = parseInt(totalForms.val()),
                     row = options.formTemplate.clone(true).removeClass('formset-custom-template'),
-                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this);
+                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this)
+                    delCssSelector = options.deleteCssClass.trim().replace(/\s+/g, '.');
                 applyExtraClasses(row, formCount);
                 row.insertBefore(buttonRow).show();
                 row.find(childElementSelector).each(function() {
                     updateElementIndex($(this), options.prefix, formCount);
                 });
                 totalForms.val(formCount + 1);
+                // Check if we're above the minimum allowed number of forms -> show all delete link(s)
+                if (showDeleteLinks()){
+                    $('a.' + delCssSelector).each(function(){$(this).show();});
+                }
                 // Check if we've exceeded the maximum allowed number of forms:
                 if (!showAddButton()) buttonRow.hide();
                 // If a post-add callback was supplied, call it with the added form:
@@ -187,7 +212,7 @@
         }
 
         return $$;
-    }
+    };
 
     /* Setup plugin defaults */
     $.fn.formset.defaults = {
@@ -203,4 +228,4 @@
         added: null,                     // Function called each time a new form is added
         removed: null                    // Function called each time a form is deleted
     };
-})(jQuery)
+})(jQuery);

--- a/demo/templates/example/min-forms.html
+++ b/demo/templates/example/min-forms.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+
+{% block title %}Basic Formset (Table layout){% endblock %}
+
+{% block extrahead %}
+<script type="text/javascript">
+    $(function() {
+        $('#id_contact_info_table tbody tr').formset({
+            extraClasses: ['row1', 'row2', 'row3']
+        })
+    })
+</script>
+<!-- Here's an example of how you can style add/delete buttons with CSS -->
+<style type="text/css">
+    .add-row {
+        padding-left:18px;
+        background:url({{ MEDIA_URL }}images/add.png) no-repeat left center;
+    }
+    .delete-row {
+        float:right;
+        display:block;
+        margin:5px 0 0 5px;
+        text-indent:-6000px;
+        background:url({{ MEDIA_URL }}images/delete.png) no-repeat left center;
+        width:16px;
+        height:16px;
+    }
+    tr.row1 td { background-color: #f9f9f9; }
+    tr.row2 td { background-color: #f3f3f3; }
+    tr.row3 td { background-color: #ededed; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div>
+    <div class="entry">
+        <form method="post" action="">
+            <table id="id_contact_info_table" border="0" cellpadding="0" cellspacing="5">
+                <thead>
+                    <tr>
+                        <th scope="col">Preferred</th>
+                        <th scope="col">Type</th>
+                        <th scope="col">Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for form in formset.forms %}
+                    <tr id="{{ form.prefix }}-row">
+                        <td style="text-align:center;">{{ form.preferred }}</td>
+                        <td>{{ form.type }}</td>
+                        <td>{{ form.value }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <p>
+                {{ formset.management_form }}
+                <input type="submit" value="Submit" />
+            </p>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<p>
+    Django 1.7 added a "MIN_NUM_FORMS" field to the management form; its value maps to the value passed in "min_num"
+    to the formset factory function.
+</p>
+<p>
+    If you're running Django 1.7+, you will be required to have at least 2 forms in this formset.
+</p>
+{% endblock %}

--- a/demo/templates/index.html
+++ b/demo/templates/index.html
@@ -19,6 +19,11 @@
             <li><a href="{% url 'example_form_template' %}">Formset with `extra = 0` (pre Django 1.2)</a></li>
             <li><a href="{% url 'example_empty_form' %}">Formset with `extra = 0` (Django 1.2+)</a></li>
             <li><a href="{% url 'example_max_forms' %}">Limit allowed forms</a></li>
+
+            {% url 'example_min_forms' as url_min_forms%}
+            {%if url_min_forms%}
+                <li><a href="{{url_min_forms}}">Require minimum forms</a></li>
+            {%endif%}
         </ul>
     </div>
 </div>

--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -16,6 +16,7 @@
             flatExtraClasses = options.extraClasses.join(' '),
             totalForms = $('#id_' + options.prefix + '-TOTAL_FORMS'),
             maxForms = $('#id_' + options.prefix + '-MAX_NUM_FORMS'),
+            minForms = $('#id_' + options.prefix + '-MIN_NUM_FORMS'),
             childElementSelector = 'input,select,textarea,label,div',
             $$ = $(this),
 
@@ -43,6 +44,14 @@
                     (maxForms.val() == '' || (maxForms.val() - totalForms.val() > 0));
             },
 
+            /**
+            * Indicates whether delete link(s) can be displayed - when total forms > min forms
+            */
+            showDeleteLinks = function() {
+                return minForms.length == 0 ||   // For Django versions pre 1.7
+                    (minForms.val() == '' || (totalForms.val() - minForms.val() > 0));
+            },
+
             insertDeleteLink = function(row) {
                 var delCssSelector = options.deleteCssClass.trim().replace(/\s+/g, '.'),
                     addCssSelector = options.addCssClass.trim().replace(/\s+/g, '.');
@@ -59,6 +68,11 @@
                     // last child element of the form's container:
                     row.append('<a class="' + options.deleteCssClass + '" href="javascript:void(0)">' + options.deleteText +'</a>');
                 }
+                // Check if we're under the minimum number of forms - not to display delete link at rendering
+                if (!showDeleteLinks()){
+                    row.find('a.' + delCssSelector).hide();
+                }
+
                 row.find('a.' + delCssSelector).click(function() {
                     var row = $(this).parents('.' + options.formCssClass),
                         del = row.find('input:hidden[id $= "-DELETE"]'),
@@ -87,6 +101,10 @@
                                 updateElementIndex($(this), options.prefix, i);
                             });
                         }
+                    }
+                    // Check if we've reached the minimum number of forms - hide all delete link(s)
+                    if (!showDeleteLinks()){
+                        $('a.' + delCssSelector).each(function(){$(this).hide();});
                     }
                     // Check if we need to show the add button:
                     if (buttonRow.is(':hidden') && showAddButton()) buttonRow.show();
@@ -173,13 +191,18 @@
             addButton.click(function() {
                 var formCount = parseInt(totalForms.val()),
                     row = options.formTemplate.clone(true).removeClass('formset-custom-template'),
-                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this);
+                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this)
+                    delCssSelector = options.deleteCssClass.trim().replace(/\s+/g, '.');
                 applyExtraClasses(row, formCount);
                 row.insertBefore(buttonRow).show();
                 row.find(childElementSelector).each(function() {
                     updateElementIndex($(this), options.prefix, formCount);
                 });
                 totalForms.val(formCount + 1);
+                // Check if we're above the minimum allowed number of forms -> show all delete link(s)
+                if (showDeleteLinks()){
+                    $('a.' + delCssSelector).each(function(){$(this).show();});
+                }
                 // Check if we've exceeded the maximum allowed number of forms:
                 if (!showAddButton()) buttonRow.hide();
                 // If a post-add callback was supplied, call it with the added form:

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -66,7 +66,7 @@
         var $totalForms = $('#id_form-TOTAL_FORMS'),
             $minForms = $('#id_form-MIN_NUM_FORMS'),
             curCount = parseInt($totalForms.val(), 10),
-            minCount = parseInt($minForms.val(), 1),
+            minCount = parseInt($minForms.val(), 10),
             $add = $('#stacked-form .add-row'),
             $del = $('#stacked-form .delete-row'),
             i;

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -62,24 +62,6 @@
         assert.ok($add.is(':visible'), 'Add button is visible again.');
     });
 
-    test('Test Min Forms', function(assert){
-        var $totalForms = $('#id_form-TOTAL_FORMS'),
-            $minForms = $('#id_form-MIN_NUM_FORMS'),
-            curCount = parseInt($totalForms.val(), 10),
-            minCount = parseInt($minForms.val(), 10),
-            $add = $('#stacked-form .add-row'),
-            $del = $('#stacked-form .delete-row'),
-            i;
-        assert.equal(curCount, minCount, 'Form count is equal to minimum allowed.');
-        assert.ok($del.first().is(':hidden'), 'Delete button is hidden.');
-        $add.trigger('click');
-        assert.ok(parseInt($totalForms.val(), 10) > parseInt($minForms.val(), 10), 'Form count is greater than minimum allowed.');
-        assert.ok($del.is(':hidden') === 0, 'Delete buttons are now all visible.');
-        $del.first().trigger('click');
-        assert.equal($totalForms.val(), $minForms.val(), 'Form count is now equal to min allowed.');
-        assert.ok($del.first().is(':hidden'), 'Delete button is hidden again.');
-    });
-
     test('Test Cloned Form Element Name', function (assert) {
         var idRegex = /id_form-(\d+)-(\w+)/,
             nameRegex = /form-(\d+)-(\w+)/;
@@ -195,5 +177,32 @@
         $btn.trigger('click');
         assert.equal($('#id_form-TOTAL_FORMS').val(), '0', 'Updated "Total Forms" count.');
         assert.equal($('#stacked-form div').size(), 0, 'Removed form.');
+    });
+
+
+    module('Basic Formset Tests', {
+        setup: function () {
+            $('#id_form-MIN_NUM_FORMS').val(1); // set 1 minimum mandatory form
+            $('#stacked-form div').formset();
+        }
+    });
+
+    test('Test Min Forms', function(assert){
+        var $totalForms = $('#id_form-TOTAL_FORMS'),
+            $minForms = $('#id_form-MIN_NUM_FORMS'),
+            curCount = parseInt($totalForms.val(), 10),
+            minCount = parseInt($minForms.val(), 10),
+            $add = $('#stacked-form .add-row'),
+            $del = $('#stacked-form .delete-row'),
+            i;
+        assert.equal(curCount, minCount, 'Form count is equal to minimum allowed.');
+        assert.ok($del.first().is(':hidden'), 'Delete button is hidden.');
+        $add.trigger('click');
+        assert.ok(parseInt($totalForms.val(), 10) > parseInt($minForms.val(), 10), 'Form count is greater than minimum allowed.');
+        console.log("test");
+        assert.ok($del.is(':hidden').length === undefined, 'Delete buttons are now all visible.');
+        $del.first().trigger('click');
+        assert.equal($totalForms.val(), $minForms.val(), 'Form count is now equal to min allowed.');
+        assert.ok($del.first().is(':hidden'), 'Delete button is hidden again.');
     });
 }(jQuery));

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -61,7 +61,25 @@
         assert.ok(parseInt($totalForms.val(), 10) < maxCount, 'Form count is now less than max allowed.');
         assert.ok($add.is(':visible'), 'Add button is visible again.');
     });
-    
+
+    test('Test Min Forms', function(assert){
+        var $totalForms = $('#id_form-TOTAL_FORMS'),
+            $minForms = $('#id_form-MIN_NUM_FORMS'),
+            curCount = parseInt($totalForms.val(), 10),
+            minCount = parseInt($minForms.val(), 1),
+            $add = $('#stacked-form .add-row'),
+            $del = $('#stacked-form .delete-row'),
+            i;
+        assert.equal(curCount, minCount, 'Form count is equal to minimum allowed.');
+        assert.ok($del.first().is(':hidden'), 'Delete button is hidden.');
+        $add.trigger('click');
+        assert.ok(curCount > minCount, 'Form count is greater than minimum allowed.');
+        assert.ok($del.is(':hidden') === 0, 'Delete buttons are now all visible.');
+        $del.first().trigger('click');
+        assert.equal(parseInt($totalForms.val(), 10), minCount, 'Form count is now equal to min allowed.');
+        assert.ok($del.first().is(':hidden'), 'Delete button is hidden again.');
+    });
+
     test('Test Cloned Form Element Name', function (assert) {
         var idRegex = /id_form-(\d+)-(\w+)/,
             nameRegex = /form-(\d+)-(\w+)/;

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -73,10 +73,10 @@
         assert.equal(curCount, minCount, 'Form count is equal to minimum allowed.');
         assert.ok($del.first().is(':hidden'), 'Delete button is hidden.');
         $add.trigger('click');
-        assert.ok(curCount > minCount, 'Form count is greater than minimum allowed.');
+        assert.ok(parseInt($totalForms.val(), 10) > parseInt($minForms.val(), 10), 'Form count is greater than minimum allowed.');
         assert.ok($del.is(':hidden') === 0, 'Delete buttons are now all visible.');
         $del.first().trigger('click');
-        assert.equal(parseInt($totalForms.val(), 10), minCount, 'Form count is now equal to min allowed.');
+        assert.equal($totalForms.val(), $minForms.val(), 'Form count is now equal to min allowed.');
         assert.ok($del.first().is(':hidden'), 'Delete button is hidden again.');
     });
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,6 +24,7 @@
             <form id="stacked-form">
                 <input type="hidden" name="form-TOTAL_FORMS" value="1" id="id_form-TOTAL_FORMS" />
                 <input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS" />
+                <input type="hidden" name="form-MIN_NUM_FORMS" value="1" id="id_form-MIN_NUM_FORMS" />
                 <input type="hidden" name="form-MAX_NUM_FORMS" value="3" id="id_form-MAX_NUM_FORMS" />
                 <div>
                     <label for="id_form-0-type">Type:</label>

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,7 +24,7 @@
             <form id="stacked-form">
                 <input type="hidden" name="form-TOTAL_FORMS" value="1" id="id_form-TOTAL_FORMS" />
                 <input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS" />
-                <input type="hidden" name="form-MIN_NUM_FORMS" value="1" id="id_form-MIN_NUM_FORMS" />
+                <input type="hidden" name="form-MIN_NUM_FORMS" value="0" id="id_form-MIN_NUM_FORMS" />
                 <input type="hidden" name="form-MAX_NUM_FORMS" value="3" id="id_form-MAX_NUM_FORMS" />
                 <div>
                     <label for="id_form-0-type">Type:</label>


### PR DESCRIPTION
With django 1.7, it's now possible to validate a minimum forms within the formset
My contribution is thus to disable delete link(s) on row(s) when miminum number of forms is reached.
I also updated qunit tests & the demo.

I hope this can help other too.