### PR TITLE
Only add remove links for current working form

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -201,7 +201,7 @@
                 totalForms.val(formCount + 1);
                 // Check if we're above the minimum allowed number of forms -> show all delete link(s)
                 if (showDeleteLinks()){
-                    $('a.' + delCssSelector).each(function(){$(this).show();});
+                    row.find('a.' + delCssSelector).show();
                 }
                 // Check if we've exceeded the maximum allowed number of forms:
                 if (!showAddButton()) buttonRow.hide();

--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -201,7 +201,7 @@
                 totalForms.val(formCount + 1);
                 // Check if we're above the minimum allowed number of forms -> show all delete link(s)
                 if (showDeleteLinks()){
-                    row.find('a.' + delCssSelector).show();
+                    $('.' + options.formCssClass).find('a.' + delCssSelector).show();
                 }
                 // Check if we've exceeded the maximum allowed number of forms:
                 if (!showAddButton()) buttonRow.hide();


### PR DESCRIPTION
When using multiple formsets, adding a new form would create remove links for every other form on the page. This was because it was searching for all elements with 'a.delete-row' (or whatever you chose as the deleteCssClass) and showing all of them, which could span across multiple formsets.

This patch just uses the formCssClass attribute to determine the formset we are working on and only shows the remove links for those elements.