### PR TITLE
bumped django version up to 1.8

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.7.1
+Django==1.8
 django-ajax-selects==1.3.5


### PR DESCRIPTION
bumping django version to 1.8 helps avoid the error described here:

http://stackoverflow.com/questions/34827566/attributeerror-module-html-parser-has-no-attribute-htmlparseerror