### PR TITLE
Add new forms before add container instead of before add link

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -205,8 +205,14 @@
             addButton.click(function() {
                 var formCount = parseInt(totalForms.val()),
                     row = options.formTemplate.clone(true).removeClass('formset-custom-template'),
-                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this),
                     delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.');
+
+                if (options.addContainerClass) {
+                    buttonRow = $('[class*="' + options.addContainerClass + '"');
+                } else {
+                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this);
+                }
+
                 applyExtraClasses(row, formCount);
                 row.insertBefore(buttonRow).show();
                 row.find(childElementSelector).each(function() {


### PR DESCRIPTION
Previous commit added possibility to put add link directely in a dedicated container, with the parameter `addConainterClass`. However, when using this parameter, new forms are put before the add link, but inside the add container. 

With this PR, if `addContainerClass`is defined, new forms are put before the container, and not inside.