### PR TITLE
Add option to hide last add form

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -315,6 +315,13 @@ complete list of available options is shown below::
         which a particular row's delete link is appended to. The container
         will be searched for within the particular row itself.
 
+.. versionadded:: 1.5
+
+    ``hideLastAddForm``
+        Set this to ``true`` to hide the last empty add form (displayed when
+        in Django ``extra`` parameter is greater than 0). The form becomes
+        visible when clicking the "add new" link.
+
 .. note:: The ``addCssClass``, ``addContainerClass`, ``deleteCssClass`` and
    ``deleteContainerClass`` options must be unique. Internally, the plugin
    uses the class names to target and place the add and delete links. Any other

--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -163,6 +163,7 @@
             } else {
                 // Otherwise, use the last form in the formset; this works much better if you've got
                 // extra (>= 1) forms (thnaks to justhamade for pointing this out):
+                if (options.hideLastAddForm) $('.' + options.formCssClass + ':last').hide();
                 template = $('.' + options.formCssClass + ':last').clone(true).removeAttr('id');
                 template.find('input:hidden[id $= "-DELETE"]').remove();
                 // Clear all cloned fields, except those the user wants to keep (thanks to brunogola for the suggestion):
@@ -242,6 +243,7 @@
         extraClasses: [],                // Additional CSS classes, which will be applied to each form in turn
         keepFieldValues: '',             // jQuery selector for fields whose values should be kept when the form is cloned
         added: null,                     // Function called each time a new form is added
-        removed: null                    // Function called each time a form is deleted
+        removed: null,                   // Function called each time a form is deleted
+        hideLastAddForm: false           // When set to true, hide last empty add form (becomes visible when clicking on add button)
     };
 })(jQuery);

--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -1,5 +1,5 @@
 /**
- * jQuery Formset 1.4-pre
+ * jQuery Formset 1.5-pre
  * @author Stanislaus Madueke (stan DOT madueke AT gmail DOT com)
  * @requires jQuery 1.2.6 or later
  *


### PR DESCRIPTION
I added the option `hideLastAddForm` which hides the last "add new" form (displayed when in Django `extra` is greater than 0). The form becomes visible when clicking the "add new" link.

Let me know if you approve this PR, then I will add documentation and version bump.