### PR TITLE
Detect automatically form prefix

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -12,8 +12,15 @@
 ;(function($) {
     $.fn.formset = function(opts)
     {
-        var options = $.extend({}, $.fn.formset.defaults, opts),
-            flatExtraClasses = options.extraClasses.join(' '),
+        var options = $.extend({}, $.fn.formset.defaults, opts);
+
+        if (options.prefix === null)
+        {
+            var raw_id = $(this).first().prev().children('input:hidden').first().attr('id');
+            options.prefix = raw_id.substring(3, raw_id.search('-'));
+        }
+
+        var flatExtraClasses = options.extraClasses.join(' '),
             totalForms = $('#id_' + options.prefix + '-TOTAL_FORMS'),
             maxForms = $('#id_' + options.prefix + '-MAX_NUM_FORMS'),
             minForms = $('#id_' + options.prefix + '-MIN_NUM_FORMS'),
@@ -230,7 +237,7 @@
 
     /* Setup plugin defaults */
     $.fn.formset.defaults = {
-        prefix: 'form',                  // The form prefix for your django formset
+        prefix: null,                    // The form prefix for your django formset (null: will detect automatically)
         formTemplate: null,              // The jQuery selection cloned to generate new form instances
         addText: 'add another',          // Text for the add link
         deleteText: 'remove',            // Text for the delete link


### PR DESCRIPTION
With this PR, when `prefix` isn't set, it will be found automatically, by looking for the hidden fields from the management form (just before the first `formset-row` as far as I am concerned).

I am not sure this works in all cases (maybe the management form isn't always before the first `formset-row` ?).

Let me know if you approve this PR, then I will document it and make the version bump.