### PR TITLE
Bug TOTAL_FORMS and delete option

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -64,11 +64,11 @@
                 } else if (row.is('TR')) {
                     // If the forms are laid out in table rows, insert
                     // the remove button into the last table cell:
-                    row.children(':last').append(deleteButtonHTML);
+                    row.children(':last').append(delButtonHTML);
                 } else if (row.is('UL') || row.is('OL')) {
                     // If they're laid out as an ordered/unordered list,
                     // insert an <li> after the last list item:
-                    row.append('<li>' + deleteButtonHTML + '</li>');
+                    row.append('<li>' + delButtonHTML + '</li>');
                 } else {
                     // Otherwise, just insert the remove button as the
                     // last child element of the form's container:

--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -92,6 +92,7 @@
                         del.val('on');
                         row.hide();
                         forms = $('.' + options.formCssClass).not(':hidden');
+                        totalForms.val(forms.length);
                     } else {
                         row.remove();
                         // Update the TOTAL_FORMS count:


### PR DESCRIPTION
**Current behaivor:** After adding forms, deleting forms works until `totalForms.val() > minForms.val()`. 
`showDeleteLinks()` returns the correct value for when the delete links should appear. But if one of the INITIAL_FORMS is deleted, then the form is not deleted but hided, and the `TOTAL_FORMS` value is not updated. For example, if you set in Django `min_num=1` and `extra=0`, then click 'add another', then delete the first of the two forms by clicking 'remove'. You end up with one row for input, but the 'remove' link is still there and allows to remove the last form too. So technically, you can remove all forms.

**Expected behaivor:** After reaching `min_num`, remove link should disappear.