### PR TITLE
Remove "visible" requirement for delete button

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -143,10 +143,8 @@
             }
             if (hasChildElements(row)) {
                 row.addClass(options.formCssClass);
-                if (row.is(':visible')) {
-                    insertDeleteLink(row);
-                    applyExtraClasses(row, i);
-                }
+                insertDeleteLink(row);
+                applyExtraClasses(row, i);
             }
         });
 


### PR DESCRIPTION
The delete button and extra classes were being applied only to visible forms. This caused forms which were not visible at start to be lacking the delete button after being displayed.