### PR TITLE
Do not decrease TOTAL_FORMS counter

### DIFF
--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -91,8 +91,10 @@
                         // and hide it, then let Django handle the deleting:
                         del.val('on');
                         row.hide();
+                        forms = $('.' + options.formCssClass).not(':hidden');
                     } else {
                         row.remove();
+                        forms = $('.' + options.formCssClass).not('.formset-custom-template');
                     }
                     for (var i=0, formCount=forms.length; i<formCount; i++) {
                         // Apply `extraClasses` to form rows so they're nicely alternating:

--- a/src/jquery.formset.js
+++ b/src/jquery.formset.js
@@ -91,13 +91,8 @@
                         // and hide it, then let Django handle the deleting:
                         del.val('on');
                         row.hide();
-                        forms = $('.' + options.formCssClass).not(':hidden');
-                        totalForms.val(forms.length);
                     } else {
                         row.remove();
-                        // Update the TOTAL_FORMS count:
-                        forms = $('.' + options.formCssClass).not('.formset-custom-template');
-                        totalForms.val(forms.length);
                     }
                     for (var i=0, formCount=forms.length; i<formCount; i++) {
                         // Apply `extraClasses` to form rows so they're nicely alternating:


### PR DESCRIPTION
As described in [my comment here](https://github.com/elo80ka/django-dynamic-formset/issues/197#issuecomment-2084806585) (Issue #197) the `TOTAL_FORMS` counter should not be decreased as Django needs that counter to handle all form data `POST`ed.